### PR TITLE
Restructure BarChart label props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.8
+
+- BarChart: Removed outdated color fallback values for labels
+- **⚠️ Breaking change:** BarChart: Restructured label props to have clearer names and nesting (see examples in readme and stories for the new format)
+
+
 # 0.0.7
 
 - Changes related to the dev/build setup and documentation

--- a/README.md
+++ b/README.md
@@ -34,20 +34,26 @@ import { BarChart } from 'react-mini-charts'
 		{
 			barWidth: '10%',
 			barColor: '#adfc92',
-			labelLeft: 'Something good',
-			labelRight: '10%',
+			labels: {
+				left: { text: 'Something good' },
+				right: { text: '10%' },
+			},
 		},
 		{
 			barWidth: '50%',
 			barColor: '#4a0d67',
-			labelLeft: 'Something mediocre',
-			labelRight: '50%',
+			labels: {
+				left: { text: 'Something mediocre' },
+				right: { text: '50%' },
+			},
 		},
 		{
 			barWidth: '40%',
 			barColor: '#db3069',
-			labelLeft: 'Something bad',
-			labelRight: '40%',
+			labels: {
+				left: { text: 'Something bad' },
+				right: { text: '40%' },
+			},
 		},
 	]}
 />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-mini-charts",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-mini-charts",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-mini-charts",
   "description": "A collection of tiny chart components for React projects.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/components/BarChart/Item/index.tsx
+++ b/src/components/BarChart/Item/index.tsx
@@ -1,26 +1,19 @@
-import { ReactNode } from 'react'
-import { Color } from '../../../common/types'
-import { BarProps } from '../types'
+import { BarChartItem } from '../types'
 import Bar from './Bar'
 import Label from './Label'
 import styles from './styles.module.css'
 
-type Props = BarProps & {
-	labelLeft?: ReactNode
-	labelRight?: ReactNode
-	labelLeftColor?: Color
-	labelRightColor?: Color
-}
+type Props = BarChartItem
 
 export default function Item(props: Props) {
-	const { barColor, barWidth, labelLeft, labelRight, labelLeftColor, labelRightColor } = props
+	const { barColor, barWidth, labels } = props
 	return (
 		<div className={styles.item}>
 			<Bar barColor={barColor} barWidth={barWidth} />
-			{(labelLeft || labelRight) && (
+			{labels && (
 				<div className={styles.labels}>
-					{labelLeft && <Label color={labelLeftColor}>{labelLeft}</Label>}
-					{labelRight && <Label color={labelRightColor}>{labelRight}</Label>}
+					{labels?.left && <Label color={labels.left.color}>{labels.left.text}</Label>}
+					{labels?.right && <Label color={labels.right.color}>{labels.right.text}</Label>}
 				</div>
 			)}
 		</div>

--- a/src/components/BarChart/index.stories.tsx
+++ b/src/components/BarChart/index.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, Story } from '@storybook/react/types-6-0'
 import React from 'react'
 import BarChart from '.'
 import styles from './styles-stories.module.css'
+import { BarChartItem } from './types'
 
 type Props = React.ComponentPropsWithoutRef<typeof BarChart>
 
@@ -12,24 +13,30 @@ export default {
 
 const Template: Story<Props> = (args) => <BarChart {...args} />
 
-const exampleChartItems = [
+const exampleChartItems: BarChartItem[] = [
 	{
 		barWidth: '10%',
 		barColor: '#adfc92',
-		labelLeft: 'Something good',
-		labelRight: '10%',
+		labels: {
+			left: { text: 'Something good' },
+			right: { text: '10%' },
+		},
 	},
 	{
 		barWidth: '50%',
 		barColor: '#4a0d67',
-		labelLeft: 'Something mediocre',
-		labelRight: '50%',
+		labels: {
+			left: { text: 'Something mediocre' },
+			right: { text: '50%' },
+		},
 	},
 	{
 		barWidth: '40%',
 		barColor: '#db3069',
-		labelLeft: 'Something bad',
-		labelRight: '40%',
+		labels: {
+			left: { text: 'Something bad' },
+			right: { text: '40%' },
+		},
 	},
 ]
 

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -17,10 +17,7 @@ export default function BarChart({ items, className }: Props) {
 					key={index}
 					barWidth={chartItem.barWidth}
 					barColor={chartItem.barColor}
-					labelLeft={chartItem.labelLeft}
-					labelRight={chartItem.labelRight}
-					labelLeftColor={chartItem.labelLeftColor}
-					labelRightColor={chartItem.labelRightColor}
+					labels={chartItem.labels}
 				/>
 			))}
 		</div>

--- a/src/components/BarChart/types.d.ts
+++ b/src/components/BarChart/types.d.ts
@@ -1,13 +1,20 @@
 import { ReactNode } from 'react'
 import { Color } from '../../common/types'
 
+type BarChartItemLabel = {
+	text: ReactNode
+	color?: Color
+}
+
+type BarChartItemLabels = {
+	left?: BarChartItemLabel
+	right?: BarChartItemLabel
+}
+
 export type BarChartItem = {
 	barWidth: string | number
 	barColor: Color
-	labelLeft?: ReactNode
-	labelRight?: ReactNode
-	labelLeftColor?: Color
-	labelRightColor?: Color
+	labels?: BarChartItemLabels
 }
 
 export type BarProps = {


### PR DESCRIPTION
Restructure BarChart’s label-related props to make their naming less redundant and to be more future-proof.